### PR TITLE
fix: remove duplicate toggle_typing_status call in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -351,7 +351,6 @@ def rasa():
         )
         if typing_status_enabled:
             toggle_typing_status(account, conversation_id, "off")
-        toggle_typing_status(account, conversation_id, "off")
     elif conversation_status == "resolved" and message_type is None and enable_csat:
         create_message = send_to_chatwoot(
             account, conversation_id, None, [], {}, None, send_csat=True


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed a duplicate call to `toggle_typing_status` in `app.py` to prevent redundant operations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Remove duplicate `toggle_typing_status` call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app.py

- Removed a duplicate call to `toggle_typing_status`.



</details>


  </td>
  <td><a href="https://github.com/truehostcloud/chatwoot-rasa-bridge/pull/5/files#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

