### PR TITLE
fix: add condition to sleep for empty bot responses before retrying

### DIFF
--- a/app.py
+++ b/app.py
@@ -153,7 +153,8 @@ def send_to_bot(sender, message, conversation_id):
 
             if not is_empty_response:
                 break
-        else:
+
+        if attempt < max_retries - 1 or is_empty_response:
             delay = (2**attempt) * base_delay
             time.sleep(delay)
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a condition to sleep for empty bot responses before retrying in `send_to_bot` function.
- Modified the retry logic to ensure the delay is applied correctly when the response is empty.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Add condition to sleep for empty bot responses before retrying</code></dd></summary>
<hr>

app.py

<li>Added a condition to sleep for empty bot responses before retrying.<br> <li> Modified the retry logic to include a check for empty responses.<br>


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/chatwoot-rasa-bridge/pull/6/files#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

